### PR TITLE
Update README.md to show macro underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ gcc patch 1.27
 * Revert SP to R10 and BP to R9
 * Add case to andhi3 to fix missed byte extend (bug manifested in libti99/vdp_bmcolor.c)
 * Replace SRL with SWPB in trunc
-* Added macros  __TMS9900_PATCH_MAJOR__ and  __TMS9900_PATCH_MINOR__ to query patch level
+* Added macros  `__TMS9900_PATCH_MAJOR__` and  `__TMS9900_PATCH_MINOR__` to query patch level
 
 gcc patch 1.26
 * Fix the regression where R11 is not saved


### PR DESCRIPTION
Macros for major and minor patch version with leading underscores does not render in markdown properly... was wondering why the macros didn't work...