### PR TITLE
Tursi's fix suggestions for unsigned char edge cases, signed division edge case, and install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ test/harness/harness
 elfutils/elf2cart
 elfutils/elf2ea5
 elfutils/ea5split
+*.o
+*.elf
+*.bin
+*.map
+

--- a/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.c
+++ b/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.c
@@ -1341,12 +1341,34 @@ extern bool tms9900_operand_subreg_offset (rtx operand, int mode)
   if (mode == HImode && offset != -1)
     return false;
 
+#if 0
   /*  If the source register is not the original register then the offset
       refers to some other decl's layout, so ignore it.  Same guard as the
       movqi insn. */
   if (ORIGINAL_REGNO (operand) != REGNO (operand))
     return false;
+#else
+    /* QImode (truncate) direction: keep the original strict rule. */
+    if (mode == QImode)
+      return ORIGINAL_REGNO (operand) == REGNO (operand);
 
+    /* HImode (extend) direction: the offset only describes the runtime byte
+       position when this rtx is reload's replacement of a paradoxical
+       (subreg:HI (reg:QI ...)).  That is the case when the rtx *is* the
+       original (hard) register, or when the original pseudo was QImode.
+       If the original pseudo was itself HImode (e.g. the destination of a
+       zero_extend), the value is already correctly positioned and the
+       offset merely records which decl byte it holds.  */
+    if (ORIGINAL_REGNO (operand) != REGNO (operand))
+      {
+        unsigned int orig = ORIGINAL_REGNO (operand);
+        if (orig < FIRST_PSEUDO_REGISTER
+            || regno_reg_rtx[orig] == NULL_RTX
+            || GET_MODE (regno_reg_rtx[orig]) != QImode)
+          return false;
+      }
+#endif
+    
   return true;
 }
 

--- a/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.md
+++ b/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.md
@@ -546,6 +546,24 @@
   {
     tms9900_debug_operands ("movhi", insn, operands, 2);
     tms9900_inline_debug ("; movhi alt=%d\n", which_alternative);
+    
+    if (which_alternative != 4
+      && REG_P (operands[1])
+      && tms9900_operand_subreg_offset (operands[1], HImode))
+    {
+      if (REG_P (operands[0]))
+        {
+          output_asm_insn ("mov  %1, %0", operands);
+          output_asm_insn ("sra  %0, 8 ; movhi subreg extend", operands);
+        }
+      else /* mem dest: can't shift memory, extend via r0 */
+        {
+          output_asm_insn ("mov  %1, r0", operands);
+          output_asm_insn ("sra  r0, 8 ; movhi subreg extend", operands);
+          output_asm_insn ("mov  r0, %0", operands);
+        }
+      return "";
+    }    
 
     if (which_alternative == 4)
     {
@@ -556,7 +574,7 @@
       return("mov  %1, %0");
     }
   }
-  [(set_attr "length" "2,4,4,6,4")])
+  [(set_attr "length" "4,8,8,10,4")])
 
 ;;-------------------------------------------------------------------
 ;; Move four-byte value as two 2-byte regs.  If immediate, emit two movhi insns
@@ -1420,7 +1438,7 @@
 ;; the shift count is a variable that had a value of 16.  In this case the compiler
 ;; emits an insn to shift by 0x10 presumably in the assumption that a shift of 0 does
 ;; nothing.  But on the tms9900 that does a shift of 16 instead which destroys
-;; the data.  The compare of the shiftcount to zero fails because 0x10 != 0.  To fix 
+;; the data.  The comparse of the shiftcount to zero fails because 0x10 != 0.  To fix 
 ;; this I have added ANDI R0,>F to ensure only the lower 4 bits are examined.  This
 ;; bloats the code unnecessarily for 16-bit ops but for now it is better to be correct
 ;; than efficient.  In the longer term it may be necessary to add back in 32-bit
@@ -1741,6 +1759,25 @@
      *  into the LSB.  Check for offsets in the operands and emit shifts to get
      *  the bytes into the right place. */
 
+    if (tms9900_operand_subreg_offset (operands[2], HImode))
+    {
+      tms9900_inline_debug ("; andhi3, op[2] off %d\n", REG_OFFSET (operands[2]));
+      if (!find_regno_note (insn, REG_DEAD, REGNO (operands[2])))
+      {
+        /* operands[2] has an offset but is not dead so we cannot change it.
+         * Move to an intermediate and swap there.  Replace op[2] with
+         * scratch reg R0 */
+        output_asm_insn ("mov  %2,r0 ; andhi3 op2 to scratch", operands);
+        output_asm_insn ("sra  r0,8 ; andhi3 extend op2", operands);
+        operands[2] = gen_rtx_REG (HImode, HARD_R0_REGNUM);
+      }
+      else
+      {
+        /* operands[2] dies here so extend in place */
+        output_asm_insn ("sra  %2,8 ; andhi3 extend op2", operands);
+      }
+    }
+
     if (tms9900_operand_subreg_offset (operands[1], HImode))
     {
       tms9900_inline_debug ("; andhi3, op[1] off %d\n", REG_OFFSET (operands[1]));
@@ -1797,7 +1834,8 @@
     }
     return(""); 
   }
-  [(set_attr "length" "6,8,8,10,2,0,4,6,8")])
+  /* warning adding 4 for the possibility of op 2 byte swap - might be less */
+  [(set_attr "length" "10,12,12,14,6,4,8,10,12")])
 
 
 (define_insn "*andnothi"
@@ -1911,6 +1949,36 @@
   {
     tms9900_debug_operands ("iorhi3", insn, operands, 3);
 
+    /* Either op[1] or op[2] may be a subreg with an offset. Correct them first. */
+
+    if (tms9900_operand_subreg_offset (operands[2], HImode))
+    {
+      tms9900_inline_debug ("; iorhi3, op[2] off %d\n", REG_OFFSET (operands[2]));
+      if (!find_regno_note (insn, REG_DEAD, REGNO (operands[2])))
+      {
+        /* operands[2] has an offset but is not dead so we cannot change it.
+         * Move to an intermediate and swap there.  Replace op[2] with
+         * scratch reg R0 */
+        output_asm_insn ("mov  %2,r0 ; iorhi op2 to scratch", operands);
+        output_asm_insn ("sra  r0,8 ; iorhi extend op2", operands);
+        operands[2] = gen_rtx_REG (HImode, HARD_R0_REGNUM);
+      }
+      else
+      {
+        /* operands[2] dies here so extend in place */
+        output_asm_insn ("sra  %2,8 ; iorhi extend op2", operands);
+      }
+    }
+
+    /* check for subreg in operand[1].  If the source register is the same as
+     * the original register, or the original is a not mem expression, then
+     * the offset refers to the register, so correction is needed */
+    if (tms9900_operand_subreg_offset (operands[1], HImode))
+    {
+      tms9900_inline_debug ("; iorhi, op[1] off %d\n", REG_OFFSET (operands[1]));
+      output_asm_insn ("sra  %1,8 ; iorhi extend op1", operands);
+    }
+
     if (which_alternative < 4)
       return("soc  %2, %0");
     else
@@ -1927,7 +1995,9 @@
       return "ori  %0, %2";
     }
   }
-  [(set_attr "length" "2,4,4,6,0,2,4")])
+  /* adding 6 to these but it depends on whether we needed to extend... */
+  /* could be up to 8 if both needed it!? */
+  [(set_attr "length" "8,10,10,12,6,8,10")])
 
 
 ;;-------------------------------------
@@ -1974,9 +2044,42 @@
   ""
   {
     tms9900_debug_operands ("xorhi3", insn, operands, 3);
+    
+    /* Either op[1] or op[2] may be a subreg with an offset. Correct them first. */
+
+    if (tms9900_operand_subreg_offset (operands[2], HImode))
+    {
+      tms9900_inline_debug ("; xorhi3, op[2] off %d\n", REG_OFFSET (operands[2]));
+      if (!find_regno_note (insn, REG_DEAD, REGNO (operands[2])))
+      {
+        /* operands[2] has an offset but is not dead so we cannot change it.
+         * Move to an intermediate and swap there.  Replace op[2] with
+         * scratch reg R0 */
+        output_asm_insn ("mov  %2,r0 ; xorhi op2 to scratch", operands);
+        output_asm_insn ("sra  r0,8 ; xorhi extend op2", operands);
+        operands[2] = gen_rtx_REG (HImode, HARD_R0_REGNUM);
+      }
+      else
+      {
+        /* operands[2] dies here so extend in place */
+        output_asm_insn ("sra  %2,8 ; xorhi extend op2", operands);
+      }
+    }
+
+    /* check for subreg in operand[1].  If the source register is the same as
+     * the original register, or the original is a not mem expression, then
+     * the offset refers to the register, so correction is needed */
+    if (tms9900_operand_subreg_offset (operands[1], HImode))
+    {
+      tms9900_inline_debug ("; xorhi, op[1] off %d\n", REG_OFFSET (operands[1]));
+      output_asm_insn ("sra  %1,8 ; xorhi extend op1", operands);
+    }
+    
     return "xor  %2, %0";
   }
-  [(set_attr "length" "2,4")])
+  /* warning: adding 6 unconditionally for the possibility of byte swap... */
+  /* it could be as low as 2 or as high as 8... if needed... */
+  [(set_attr "length" "8,10")])
 
 
 ;;-------------------------------------

--- a/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.md
+++ b/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.md
@@ -2749,7 +2749,7 @@
     rtx tmp = gen_reg_rtx (HImode);
     emit_move_insn(tmp, operands[1]);
     emit_insn(gen_abshi2(tmp, tmp));
-    emit_insn(gen_extendhisi2 (dividend, tmp));
+    emit_insn(gen_zero_extendhisi2 (dividend, tmp));
 
     /* Perform division and modulus */
     emit_insn(gen_udivmodsihi3(dividend, dividend, divisor));

--- a/install.sh
+++ b/install.sh
@@ -124,9 +124,10 @@ if [ ! -f .binutils_built ] ; then
    cd $BINUTILS_VERSION
    ./configure --target tms9900 --prefix $PREFIX --disable-build-warnings
    check_result "=== Failed to configure Binutils ==="
-   make all
+   # MAKEINFO=true skips building the info docs, which fail with texinfo >= 5
+   make all MAKEINFO=true
    check_result "=== Failed to build Binutils ==="
-   make install
+   make install MAKEINFO=true
    check_result "=== Failed to install Binutils ==="
    cd ..
    touch .binutils_built
@@ -139,11 +140,11 @@ if [ ! -f .gcc_built ] ; then
    cd build
    ../configure --prefix $PREFIX --target=tms9900 --enable-languages=c,c++
    check_result "=== Failed to configure GCC ==="
-   make all-gcc
+   make all-gcc MAKEINFO=true
    check_result "=== Failed to build GCC ==="
-   make all-target-libgcc
+   make all-target-libgcc MAKEINFO=true
    check_result "=== Failed to build libgcc ==="
-   make install-gcc install-target-libgcc
+   make install-gcc install-target-libgcc MAKEINFO=true
    # Make install has an expected failure:
    #  /bin/bash: line 3: cd: tms9900/libssp: No such file or directory
    # We do not build libssp, so that's OK
@@ -156,9 +157,9 @@ if [ ! -f .libgcc_built ] ; then
    cd $GCC_VERSION
    mkdir build
    cd build
-   make  all-target-libgcc
+   make  all-target-libgcc MAKEINFO=true
    check_result "=== Failed to build libgcc.a ==="
-   make install-target-libgcc
+   make install-target-libgcc MAKEINFO=true
    check_result "=== Failed to build libgcc.a ==="
    cd ../..
    touch .libgcc_built

--- a/test/harness/Makefile
+++ b/test/harness/Makefile
@@ -4,9 +4,7 @@ unasm.o \
 parse.o \
 harness-mem.o 
 
-LIBS=\
--lreadline \
--lm 
+LIBS=-lm
 
 CFLAGS=-Wall -ggdb3
 # LDFLAGS=

--- a/test/test_bitfield.c
+++ b/test/test_bitfield.c
@@ -1,0 +1,115 @@
+/*  Quick sanity check that struct bitfields work: set/get, signed fields,
+ *  a field straddling a 16-bit word boundary, read-modify-write, and
+ *  char-container fields.  Not comprehensive. */
+
+#include "tap.h"
+
+struct bf
+{
+    unsigned a : 3;
+    unsigned b : 5;
+    unsigned c : 7;
+    signed   d : 4;   /* straddles the first 16-bit word */
+    unsigned e : 13;
+};
+
+struct cbf
+{
+    unsigned char x : 2;
+    unsigned char y : 3;
+    signed char   z : 3;
+};
+
+static struct bf g = { 5, 21, 100, -3, 4321 };
+
+static unsigned __attribute__ ((noinline)) get_b (struct bf *p) { return p->b; }
+static int      __attribute__ ((noinline)) get_d (struct bf *p) { return p->d; }
+static void     __attribute__ ((noinline)) set_d (struct bf *p, int v) { p->d = v; }
+
+void t_bf_init (void)
+{
+    /* static initializer laid down by the compiler, read back at runtime */
+    test_execute (__func__, g.a == 5);
+    test_execute (__func__, g.b == 21);
+    test_execute (__func__, g.c == 100);
+    test_execute (__func__, g.d == -3);
+    test_execute (__func__, g.e == 4321);
+}
+
+void t_bf_setget (void)
+{
+    volatile struct bf s;
+
+    s.a = 7; s.b = 0; s.c = 127; s.d = -8; s.e = 8191;
+    test_execute (__func__, s.a == 7);
+    test_execute (__func__, s.b == 0);
+    test_execute (__func__, s.c == 127);
+    test_execute (__func__, s.d == -8);
+    test_execute (__func__, s.e == 8191);
+
+    /* neighbours untouched after single-field writes */
+    s.b = 31;
+    s.d = 7;
+    test_execute (__func__, s.a == 7 && s.c == 127 && s.e == 8191);
+    test_execute (__func__, s.b == 31);
+    test_execute (__func__, s.d == 7);
+
+    /* wraparound on overflow */
+    s.a = 9;            /* 3 bits: 9 & 7 == 1 */
+    test_execute (__func__, s.a == 1);
+}
+
+void t_bf_rmw (void)
+{
+    struct bf s = { 1, 2, 3, 1, 5 };
+
+    s.b += 10;
+    s.d -= 4;
+    s.c ^= 0x55;
+    test_execute (__func__, s.b == 12);
+    test_execute (__func__, s.d == -3);
+    test_execute (__func__, s.c == (3 ^ 0x55));
+    test_execute (__func__, s.a == 1 && s.e == 5);
+}
+
+void t_bf_calls (void)
+{
+    set_d (&g, -4);
+    test_execute (__func__, get_d (&g) == -4);
+    test_execute (__func__, get_b (&g) == 21);
+    set_d (&g, 3);
+    test_execute (__func__, get_d (&g) == 3);
+    test_execute (__func__, g.c == 100 && g.e == 4321);
+}
+
+void t_bf_char (void)
+{
+    volatile struct cbf s;
+
+    s.x = 3; s.y = 5; s.z = -2;
+    test_execute (__func__, s.x == 3);
+    test_execute (__func__, s.y == 5);
+    test_execute (__func__, s.z == -2);
+    // Claude wrote this as ==1, then acknowledged that all structs
+    // are padded to a multiple of 2 bytes on this compiler, which
+    // is sensible, so I've fixed the test.
+    test_execute (__func__, sizeof (struct cbf) == 2);
+}
+
+TESTFUNC tests[] =
+{
+    t_bf_init,
+    t_bf_setget,
+    t_bf_rmw,
+    t_bf_calls,
+    t_bf_char
+};
+
+#define TEST_COUNT (sizeof (tests) / sizeof (TESTFUNC))
+
+int main (void)
+{
+    test_run (tests, TEST_COUNT);
+
+    return 0;
+}

--- a/test/test_sdiv.c
+++ b/test/test_sdiv.c
@@ -1,0 +1,269 @@
+/*
+ *  Signed division / modulo tests for 8-bit (signed char) and 16-bit (int)
+ *  operands.  C99 6.5.5: division truncates toward zero, and
+ *  (a/b)*b + a%b == a, so the remainder takes the sign of the dividend.
+ *
+ *  Values are loaded through volatile locals so the divisions cannot be
+ *  constant-folded, and additionally through noinline helper functions to
+ *  exercise the byte argument-passing / return convention.
+ */
+
+#include "tap.h"
+
+typedef struct
+{
+    signed char a;
+    signed char b;
+    signed char div;    /* a / b */
+    signed char mod;    /* a % b */
+} case8_t;
+
+static const case8_t c8[] =
+{
+    /* sign combinations, small values */
+    {    7,    3,    2,    1 },
+    {   -7,    3,   -2,   -1 },
+    {    7,   -3,   -2,    1 },
+    {   -7,   -3,    2,   -1 },
+
+    /* discriminates signed vs unsigned interpretation of the dividend:
+     * unsigned 255/2 would give 127, signed -1/2 must give 0 r -1 */
+    {   -1,    2,    0,   -1 },
+    {   -1,    1,   -1,    0 },
+
+    /* full-range byte values */
+    {  127,    7,   18,    1 },
+    { -127,    7,  -18,   -1 },
+    {  127,   -7,  -18,    1 },
+    { -127,   -7,   18,   -1 },
+
+    /* SCHAR_MIN edges (avoiding -128 / -1 which is undefined) */
+    { -128,    1, -128,    0 },
+    { -128,    2,  -64,    0 },
+    { -128,   -2,   64,    0 },
+    { -128,    7,  -18,   -2 },
+
+    /* quotient zero */
+    {    5,  127,    0,    5 },
+    {   -5,  127,    0,   -5 },
+    {    5, -127,    0,    5 },
+    {   -5, -128,    0,   -5 },
+
+    /* exact divisions */
+    {  126,   -9,  -14,    0 },
+    { -125,    5,  -25,    0 },
+};
+
+typedef struct
+{
+    int a;
+    int b;
+    int div;    /* a / b */
+    int mod;    /* a % b */
+} case16_t;
+
+static const case16_t c16[] =
+{
+    /* sign combinations, small values */
+    {      7,      3,      2,    1 },
+    {     -7,      3,     -2,   -1 },
+    {      7,     -3,     -2,    1 },
+    {     -7,     -3,      2,   -1 },
+
+    /* discriminates signed vs unsigned: unsigned 0xFFFF/2 = 32767 */
+    {     -1,      2,      0,   -1 },
+
+    /* two-byte values, all sign combinations */
+    {    479,     57,      8,   23 },
+    {   -479,     57,     -8,  -23 },
+    {    479,    -57,     -8,   23 },
+    {   -479,    -57,      8,  -23 },
+
+    /* large dividends (top bit of magnitude set in the word) */
+    {  30000,      7,   4285,    5 },
+    { -30000,      7,  -4285,   -5 },
+    {  30000,     -7,  -4285,    5 },
+    { -30000,     -7,   4285,   -5 },
+
+    /* INT_MIN edges (avoiding -32768 / -1 which is undefined) */
+    { -32768,      1, -32768,    0 },
+    { -32768,      2, -16384,    0 },
+    { -32768,     -2,  16384,    0 },
+    { -32768,      7,  -4681,   -1 },
+    { -32768,  32767,     -1,   -1 },
+
+    /* division by +-1 of extremes */
+    {  32767,     -1, -32767,    0 },
+    { -32767,     -1,  32767,    0 },
+
+    /* quotient zero */
+    {      5,  32767,      0,    5 },
+    {     -5,  32767,      0,   -5 },
+    {     -5, -32768,      0,   -5 },
+
+    /* divisor larger than dividend in magnitude, both large */
+    {  12345, -23456,      0, 12345 },
+    { -12345,  23456,      0, -12345 },
+
+    /* exact divisions */
+    {  32130,    255,    126,    0 },
+    { -32130,    255,   -126,    0 },
+};
+
+#define COUNT8  (sizeof (c8)  / sizeof (c8[0]))
+#define COUNT16 (sizeof (c16) / sizeof (c16[0]))
+
+/*  noinline helpers force the values through the QI argument / return
+ *  convention (value in high byte of a word register) */
+static signed char __attribute__ ((noinline)) sdiv8 (signed char a, signed char b)
+{
+    return a / b;
+}
+
+static signed char __attribute__ ((noinline)) smod8 (signed char a, signed char b)
+{
+    return a % b;
+}
+
+static int __attribute__ ((noinline)) sdiv16 (int a, int b)
+{
+    return a / b;
+}
+
+static int __attribute__ ((noinline)) smod16 (int a, int b)
+{
+    return a % b;
+}
+
+void t_i8_div (void)
+{
+    for (unsigned i = 0; i < COUNT8; i++)
+    {
+        volatile signed char va = c8[i].a;
+        volatile signed char vb = c8[i].b;
+        signed char q = va / vb;
+
+        if (q != c8[i].div)
+            test_printf ("i8 %d / %d == %d should be %d\n",
+                         c8[i].a, c8[i].b, q, c8[i].div);
+
+        test_execute (__func__, q == c8[i].div);
+    }
+}
+
+void t_i8_mod (void)
+{
+    for (unsigned i = 0; i < COUNT8; i++)
+    {
+        volatile signed char va = c8[i].a;
+        volatile signed char vb = c8[i].b;
+        signed char r = va % vb;
+
+        if (r != c8[i].mod)
+            test_printf ("i8 %d %% %d == %d should be %d\n",
+                         c8[i].a, c8[i].b, r, c8[i].mod);
+
+        test_execute (__func__, r == c8[i].mod);
+    }
+}
+
+void t_i8_div_call (void)
+{
+    for (unsigned i = 0; i < COUNT8; i++)
+    {
+        signed char q = sdiv8 (c8[i].a, c8[i].b);
+        signed char r = smod8 (c8[i].a, c8[i].b);
+
+        if (q != c8[i].div || r != c8[i].mod)
+            test_printf ("i8 call %d /%% %d == %d,%d should be %d,%d\n",
+                         c8[i].a, c8[i].b, q, r, c8[i].div, c8[i].mod);
+
+        test_execute (__func__, q == c8[i].div && r == c8[i].mod);
+    }
+}
+
+/*  8-bit operands with the result widened to int before use, so the
+ *  division runs in HImode and the QI operands must be sign-extended */
+void t_i8_div_widened (void)
+{
+    for (unsigned i = 0; i < COUNT8; i++)
+    {
+        volatile signed char va = c8[i].a;
+        volatile signed char vb = c8[i].b;
+        int q = va / vb;
+        int r = va % vb;
+
+        if (q != c8[i].div || r != c8[i].mod)
+            test_printf ("i8 wide %d /%% %d == %d,%d should be %d,%d\n",
+                         c8[i].a, c8[i].b, q, r, c8[i].div, c8[i].mod);
+
+        test_execute (__func__, q == c8[i].div && r == c8[i].mod);
+    }
+}
+
+void t_i16_div (void)
+{
+    for (unsigned i = 0; i < COUNT16; i++)
+    {
+        volatile int va = c16[i].a;
+        volatile int vb = c16[i].b;
+        int q = va / vb;
+
+        if (q != c16[i].div)
+            test_printf ("i16 %d / %d == %d should be %d\n",
+                         c16[i].a, c16[i].b, q, c16[i].div);
+
+        test_execute (__func__, q == c16[i].div);
+    }
+}
+
+void t_i16_mod (void)
+{
+    for (unsigned i = 0; i < COUNT16; i++)
+    {
+        volatile int va = c16[i].a;
+        volatile int vb = c16[i].b;
+        int r = va % vb;
+
+        if (r != c16[i].mod)
+            test_printf ("i16 %d %% %d == %d should be %d\n",
+                         c16[i].a, c16[i].b, r, c16[i].mod);
+
+        test_execute (__func__, r == c16[i].mod);
+    }
+}
+
+void t_i16_div_call (void)
+{
+    for (unsigned i = 0; i < COUNT16; i++)
+    {
+        int q = sdiv16 (c16[i].a, c16[i].b);
+        int r = smod16 (c16[i].a, c16[i].b);
+
+        if (q != c16[i].div || r != c16[i].mod)
+            test_printf ("i16 call %d /%% %d == %d,%d should be %d,%d\n",
+                         c16[i].a, c16[i].b, q, r, c16[i].div, c16[i].mod);
+
+        test_execute (__func__, q == c16[i].div && r == c16[i].mod);
+    }
+}
+
+TESTFUNC tests[] =
+{
+    t_i8_div,
+    t_i8_mod,
+    t_i8_div_call,
+    t_i8_div_widened,
+    t_i16_div,
+    t_i16_mod,
+    t_i16_div_call
+};
+
+#define TEST_COUNT (sizeof (tests) / sizeof (TESTFUNC))
+
+int main (void)
+{
+    test_run (tests, TEST_COUNT);
+
+    return 0;
+}


### PR DESCRIPTION
tms9900.c
- Fix for char returns->and, and or-or-or cases
    - added some extra logic to tms9900_operand_subreg_offset to better identify valid cases
    - left the original code ifdef'd out of cowardice

tms9900.md
- Fix for char returns->and, and or-or-or cases
    - added byte correction code to movhi, andhi3, iorhi3, xorhi3
- Fix for signed divsion case of x/-32768
    - use fixed zero extend as denominator is unsigned at this point in the process
    
test harness
- removed -lreadline from Makefile (your mileage may vary, I guess)
- added test_bitfield.c
- added test_sdiv.c    

install.sh
- added MAKEINFO=true to skip the texinfo documentation, which is now obsolete and doesn't like modern environments

gitignore
- added .o, .elf, .bin, .map

Suggestions mostly made by Claude, but tested against my libti99all (library, example, testlib), desktop and minestorm apps.
