### PR TITLE
Fix for signed division on longs

### DIFF
--- a/dev/gcc-4.4.0/gcc/config/tms9900/lib1funcs.asm
+++ b/dev/gcc-4.4.0/gcc/config/tms9900/lib1funcs.asm
@@ -534,13 +534,14 @@ savemod:
   mov  *r10, r0
   mov  r3, *r0+
   mov  r4, *r0
+  
+  bl   @__divmodend      ; apply sign (reads R5) BEFORE restoring R5    
 
   /* Restore from stack */
   mov  *r10+, r5
   mov  *r10+, r11
+  b    *r11
 
-  /* Complete operatons */
-  b    @__divmodend
 #endif
 
 
@@ -567,12 +568,12 @@ __divsi3:
   /* Caclulate result */
 calc:
   bl   @__udivmod32
+  bl   @__divmodend      ; apply sign (reads R5) BEFORE restoring R5  
 
   /* Restore from stack */
   mov  *r10+, r5
   mov  *r10+, r11
-
-  b    @__divmodend
+  b    *r11
 #endif
 
 
@@ -602,11 +603,12 @@ calc:
   mov  r3, r1
   mov  r4, r2
 
+  bl   @__divmodend      ; apply sign (reads R5) BEFORE restoring R5  
+    
   /* Restore from stack */
   mov  *r10+, r5
   mov  *r10+, r11
-
-  b    @__divmodend
+  b    *r11
 #endif
 
 

--- a/test/test_repro.c
+++ b/test/test_repro.c
@@ -1,0 +1,44 @@
+#include "tap.h"
+#include "params.h"
+
+/* variable divisor -- deterministically failed at -Os before the fix */
+void t_var(void)
+{
+    static const long in[] = { 2000, 24000, 108000, 100000, 700, 1500, -2000, 2000 };
+    static const long dv[] = {    5,     2,      9,      5,   2,    3,     5,   -5 };
+    static const long ex[] = {  400, 12000,  12000,  20000, 350,  500,  -400, -400 };
+    unsigned i;
+    for (i = 0; i < 8; i++) {
+        set_sl_x(in[i]); set_sl_y(dv[i]);
+        test_execute("var", (sl_x / sl_y) == ex[i]);
+    }
+}
+
+/* constant /5 with a negative entry in the table -- failed before the fix */
+void t_const(void)
+{
+    static const long in[] = { 2000, 24000, 108000, -2000, 140, 500 };
+    static const long ex[] = {  400,  4800,  21600,  -400,  28, 100 };
+    unsigned i;
+    for (i = 0; i < 6; i++) {
+        set_sl_x(in[i]);
+        test_execute("const5", (sl_x / 5) == ex[i]);
+    }
+}
+
+/* the exact Taipan shock: positive price /5 must stay positive */
+void t_shock(void)
+{
+    static const long price[] = { 500, 700, 1500, 2100, 24000, 108000 };
+    unsigned i;
+    for (i = 0; i < 6; i++) {
+        set_sl_x(price[i]);
+        long cp = sl_x / 5;
+        if (cp < 1) cp = 1;
+        test_execute("shock_ge2", cp >= 2);   /* must NOT get clamped to 1 */
+    }
+}
+
+TESTFUNC tests[] = { t_var, t_const, t_shock };
+#define TEST_COUNT (sizeof (tests) / sizeof (TESTFUNC))
+int main(void) { test_run (tests, TEST_COUNT); return 0; }

--- a/test/test_taipandiv.c
+++ b/test/test_taipandiv.c
@@ -1,0 +1,78 @@
+#include "tap.h"
+#include "params.h"
+
+/* reconstruct an actual 32-bit result via 32 pass/fail bit probes */
+static void probe_bits(const char *name, long got, long expect)
+{
+    int b;
+    test_execute(name, got == expect);
+    for (b = 0; b < 32; b++)
+        test_execute("bit", ((got >> b) & 1) == ((expect >> b) & 1));
+}
+
+/* signed long / 5 across the 65535 boundary */
+void t_div5_boundary(void)
+{
+    static const struct { long in; long out; } c[] = {
+        {  65530, 13106 },
+        {  65535, 13107 },
+        {  65536, 13107 },
+        {  70000, 14000 },
+        { 100000, 20000 }
+    };
+    unsigned i;
+    for (i = 0; i < sizeof(c)/sizeof(c[0]); i++) {
+        set_sl_x(c[i].in);
+        probe_bits("div5", sl_x / 5, c[i].out);
+    }
+}
+
+/* unsigned long % n  -- exactly what rnd() computes */
+void t_umod(void)
+{
+    static const struct { unsigned long a; unsigned long b; long out; } c[] = {
+        { 0x0001A5E0UL, 3, 0 },
+        { 0x12345678UL, 3, 0 },
+        { 0xABCD1234UL, 4, 0 },
+        { 0xFFFFFFFFUL, 5, 0 },
+        { 0x80000000UL, 10, 8 },
+        { 0x00012345UL, 9, 0 }
+    };
+    unsigned i;
+    for (i = 0; i < sizeof(c)/sizeof(c[0]); i++) {
+        set_ul_x(c[i].a); set_ul_y(c[i].b);
+        probe_bits("umod", (long)(ul_x % ul_y), c[i].out);
+    }
+}
+
+/* unsigned long / n with high word set */
+void t_udiv(void)
+{
+    static const struct { unsigned long a; unsigned long b; long out; } c[] = {
+        { 0x00010000UL, 5, 13107 },
+        { 0x000186A0UL, 5, 20000 },
+        { 0xFFFFFFFFUL, 65536, 65535 }
+    };
+    unsigned i;
+    for (i = 0; i < sizeof(c)/sizeof(c[0]); i++) {
+        set_ul_x(c[i].a); set_ul_y(c[i].b);
+        probe_bits("udiv", (long)(ul_x / ul_y), c[i].out);
+    }
+}
+
+#include "ltoa.c"
+
+TESTFUNC tests[] =
+{
+    t_div5_boundary,
+    t_umod,
+    t_udiv
+};
+
+#define TEST_COUNT (sizeof (tests) / sizeof (TESTFUNC))
+
+int main(void)
+{
+    test_run (tests, TEST_COUNT);
+    return 0;
+}


### PR DESCRIPTION
The register that tracked sign was being overwritten before it was being applied to the answer.
Added two tests that reproduced the issue.

Tests were again created by Claude, fix was done by hand. Regression tests were also run.