### PR TITLE
Better fix for division with longs

### DIFF
--- a/dev/gcc-4.4.0/gcc/config/tms9900/lib1funcs.asm
+++ b/dev/gcc-4.4.0/gcc/config/tms9900/lib1funcs.asm
@@ -534,13 +534,14 @@ savemod:
   mov  *r10, r0
   mov  r3, *r0+
   mov  r4, *r0
+  
+  bl   @__divmodend      ; apply sign (reads R5) BEFORE restoring R5    
 
   /* Restore from stack */
   mov  *r10+, r5
   mov  *r10+, r11
+  b    *r11
 
-  /* Complete operatons */
-  b    @__divmodend
 #endif
 
 
@@ -567,12 +568,12 @@ __divsi3:
   /* Caclulate result */
 calc:
   bl   @__udivmod32
+  bl   @__divmodend      ; apply sign (reads R5) BEFORE restoring R5  
 
   /* Restore from stack */
   mov  *r10+, r5
   mov  *r10+, r11
-
-  b    @__divmodend
+  b    *r11
 #endif
 
 
@@ -602,11 +603,12 @@ calc:
   mov  r3, r1
   mov  r4, r2
 
+  bl   @__divmodend      ; apply sign (reads R5) BEFORE restoring R5  
+    
   /* Restore from stack */
   mov  *r10+, r5
   mov  *r10+, r11
-
-  b    @__divmodend
+  b    *r11
 #endif
 
 

--- a/dev/gcc-4.4.0/gcc/config/tms9900/lib1funcs.asm
+++ b/dev/gcc-4.4.0/gcc/config/tms9900/lib1funcs.asm
@@ -514,6 +514,8 @@ __divmodsi3:
   mov  r11,*r10
   dect r10
   mov  r5,*r10
+  dect r10
+  mov  r1,*r10    ; save original numerator for sign
 
   bl   @__divmodstart
 
@@ -534,8 +536,9 @@ savemod:
   mov  *r10, r0
   mov  r3, *r0+
   mov  r4, *r0
-  
-  bl   @__divmodend      ; apply sign (reads R5) BEFORE restoring R5    
+
+  mov *r10+,r5           ; get original numerator sign  
+  bl   @__divmodend      ; apply sign (reads R5)
 
   /* Restore from stack */
   mov  *r10+, r5
@@ -595,6 +598,8 @@ __modsi3:
   mov  r11,*r10  ; save r11
   dect r10
   mov  r5,*r10  ; save r5
+  dect r10
+  mov  r1,*r10  ; save ORIGINAL numerator high word (dividend sign)
   bl   @__divmodstart
 
   /* Caclulate result */
@@ -603,7 +608,8 @@ calc:
   mov  r3, r1
   mov  r4, r2
 
-  bl   @__divmodend      ; apply sign (reads R5) BEFORE restoring R5  
+  mov  *r10+, r5         ; r5 = original numerator high for it's sign bit
+  bl   @__divmodend      ; apply the NUMERATOR (DIVIDEND) sign to the remainder
     
   /* Restore from stack */
   mov  *r10+, r5

--- a/test/test_mod.c
+++ b/test/test_mod.c
@@ -1,0 +1,26 @@
+#include "tap.h"
+#include "params.h"
+
+/* C99 6.5.5: remainder takes the sign of the DIVIDEND (a in a%b).
+ * (a/b)*b + a%b == a. */
+void t_mod(void)
+{
+    static const struct { long a; long b; long r; } c[] = {
+        {  13,  5,  3 }, {  13, -5,  3 }, { -13,  5, -3 }, { -13, -5, -3 },
+        {  17,  5,  2 }, {  17, -5,  2 }, { -17,  5, -2 }, { -17, -5, -2 },
+        { 100000,  7,  100000L % 7 },  { -100000,  7, -(100000L % 7) },
+        { 100000, -7,  100000L % 7 },  { -100000, -7, -(100000L % 7) }
+    };
+    unsigned i;
+    for (i = 0; i < sizeof(c)/sizeof(c[0]); i++) {
+        set_sl_x(c[i].a); set_sl_y(c[i].b);
+        long got = sl_x % sl_y;
+        test_execute("mod", got == c[i].r);
+        /* identity check */
+        test_execute("identity", (sl_x / sl_y) * sl_y + got == c[i].a);
+    }
+}
+
+TESTFUNC tests[] = { t_mod };
+#define TEST_COUNT (sizeof (tests) / sizeof (TESTFUNC))
+int main(void) { test_run (tests, TEST_COUNT); return 0; }

--- a/test/test_mod16.c
+++ b/test/test_mod16.c
@@ -1,0 +1,38 @@
+#include "tap.h"
+#include "params.h"
+
+/* 16-bit signed div/mod with negative divisors -- the inline divmodhi4 path.
+ * ss_x/ss_y are 'short' globals (set_ss_*) so no constant folding. */
+void t_div16(void)
+{
+    static const struct { short a; short b; short q; short r; } c[] = {
+        {  13,  5,  2,  3 }, {  13, -5, -2,  3 }, { -13,  5, -2, -3 }, { -13, -5,  2, -3 },
+        {  17,  5,  3,  2 }, {  17, -5, -3,  2 }, { -17,  5, -3, -2 }, { -17, -5,  3, -2 },
+        { 30000,  7, 30000/7, 30000%7 }, { -30000,  7, -(30000/7), -(30000%7) },
+        { 30000, -7, -(30000/7), 30000%7 }, { -30000, -7, 30000/7, -(30000%7) }
+    };
+    unsigned i;
+    for (i = 0; i < sizeof(c)/sizeof(c[0]); i++) {
+        set_ss_x(c[i].a); set_ss_y(c[i].b);
+        test_execute("div16", (ss_x / ss_y) == c[i].q);
+        test_execute("mod16", (ss_x % ss_y) == c[i].r);
+        test_execute("id16",  (ss_x / ss_y) * ss_y + (ss_x % ss_y) == c[i].a);
+    }
+}
+
+/* 8-bit signed mod with negative divisor -- divmodqi4 path */
+void t_mod8(void)
+{
+    static const struct { char a; char b; char r; } c[] = {
+        { 13, 5, 3 }, { 13, -5, 3 }, { -13, 5, -3 }, { -13, -5, -3 }
+    };
+    unsigned i;
+    for (i = 0; i < 4; i++) {
+        set_sc_x(c[i].a); set_sc_y(c[i].b);
+        test_execute("mod8", (char)(sc_x % sc_y) == c[i].r);
+    }
+}
+
+TESTFUNC tests[] = { t_div16, t_mod8 };
+#define TEST_COUNT (sizeof (tests) / sizeof (TESTFUNC))
+int main(void) { test_run (tests, TEST_COUNT); return 0; }

--- a/test/test_repro.c
+++ b/test/test_repro.c
@@ -1,0 +1,44 @@
+#include "tap.h"
+#include "params.h"
+
+/* variable divisor -- deterministically failed at -Os before the fix */
+void t_var(void)
+{
+    static const long in[] = { 2000, 24000, 108000, 100000, 700, 1500, -2000, 2000 };
+    static const long dv[] = {    5,     2,      9,      5,   2,    3,     5,   -5 };
+    static const long ex[] = {  400, 12000,  12000,  20000, 350,  500,  -400, -400 };
+    unsigned i;
+    for (i = 0; i < 8; i++) {
+        set_sl_x(in[i]); set_sl_y(dv[i]);
+        test_execute("var", (sl_x / sl_y) == ex[i]);
+    }
+}
+
+/* constant /5 with a negative entry in the table -- failed before the fix */
+void t_const(void)
+{
+    static const long in[] = { 2000, 24000, 108000, -2000, 140, 500 };
+    static const long ex[] = {  400,  4800,  21600,  -400,  28, 100 };
+    unsigned i;
+    for (i = 0; i < 6; i++) {
+        set_sl_x(in[i]);
+        test_execute("const5", (sl_x / 5) == ex[i]);
+    }
+}
+
+/* the exact Taipan shock: positive price /5 must stay positive */
+void t_shock(void)
+{
+    static const long price[] = { 500, 700, 1500, 2100, 24000, 108000 };
+    unsigned i;
+    for (i = 0; i < 6; i++) {
+        set_sl_x(price[i]);
+        long cp = sl_x / 5;
+        if (cp < 1) cp = 1;
+        test_execute("shock_ge2", cp >= 2);   /* must NOT get clamped to 1 */
+    }
+}
+
+TESTFUNC tests[] = { t_var, t_const, t_shock };
+#define TEST_COUNT (sizeof (tests) / sizeof (TESTFUNC))
+int main(void) { test_run (tests, TEST_COUNT); return 0; }

--- a/test/test_taipandiv.c
+++ b/test/test_taipandiv.c
@@ -1,0 +1,78 @@
+#include "tap.h"
+#include "params.h"
+
+/* reconstruct an actual 32-bit result via 32 pass/fail bit probes */
+static void probe_bits(const char *name, long got, long expect)
+{
+    int b;
+    test_execute(name, got == expect);
+    for (b = 0; b < 32; b++)
+        test_execute("bit", ((got >> b) & 1) == ((expect >> b) & 1));
+}
+
+/* signed long / 5 across the 65535 boundary */
+void t_div5_boundary(void)
+{
+    static const struct { long in; long out; } c[] = {
+        {  65530, 13106 },
+        {  65535, 13107 },
+        {  65536, 13107 },
+        {  70000, 14000 },
+        { 100000, 20000 }
+    };
+    unsigned i;
+    for (i = 0; i < sizeof(c)/sizeof(c[0]); i++) {
+        set_sl_x(c[i].in);
+        probe_bits("div5", sl_x / 5, c[i].out);
+    }
+}
+
+/* unsigned long % n  -- exactly what rnd() computes */
+void t_umod(void)
+{
+    static const struct { unsigned long a; unsigned long b; long out; } c[] = {
+        { 0x0001A5E0UL, 3, 0 },
+        { 0x12345678UL, 3, 0 },
+        { 0xABCD1234UL, 4, 0 },
+        { 0xFFFFFFFFUL, 5, 0 },
+        { 0x80000000UL, 10, 8 },
+        { 0x00012345UL, 9, 0 }
+    };
+    unsigned i;
+    for (i = 0; i < sizeof(c)/sizeof(c[0]); i++) {
+        set_ul_x(c[i].a); set_ul_y(c[i].b);
+        probe_bits("umod", (long)(ul_x % ul_y), c[i].out);
+    }
+}
+
+/* unsigned long / n with high word set */
+void t_udiv(void)
+{
+    static const struct { unsigned long a; unsigned long b; long out; } c[] = {
+        { 0x00010000UL, 5, 13107 },
+        { 0x000186A0UL, 5, 20000 },
+        { 0xFFFFFFFFUL, 65536, 65535 }
+    };
+    unsigned i;
+    for (i = 0; i < sizeof(c)/sizeof(c[0]); i++) {
+        set_ul_x(c[i].a); set_ul_y(c[i].b);
+        probe_bits("udiv", (long)(ul_x / ul_y), c[i].out);
+    }
+}
+
+#include "ltoa.c"
+
+TESTFUNC tests[] =
+{
+    t_div5_boundary,
+    t_umod,
+    t_udiv
+};
+
+#define TEST_COUNT (sizeof (tests) / sizeof (TESTFUNC))
+
+int main(void)
+{
+    test_run (tests, TEST_COUNT);
+    return 0;
+}


### PR DESCRIPTION
- The register that tracked sign was being overwritten before it was being applied to the answer.
- long modulo was applying the sign of the result rather than the sign of the dividend as c99 requires

Added four tests that reproduced the issues.
Tests were again created by Claude, fix was done by hand. Regression tests were also run.
