### PR TITLE
Fix for incorrect function pointer compilation

### DIFF
--- a/dev/gcc-4.4.0/gcc/config/tms9900/tms9900-protos.h
+++ b/dev/gcc-4.4.0/gcc/config/tms9900/tms9900-protos.h
@@ -63,3 +63,4 @@ extern bool tms9900_constant_address_p (rtx x);
 extern bool tms9900_operand_subreg_offset (rtx operand, int mode);
 extern void tms9900_inline_debug (const char *fmt,...);
 extern void tms9900_debug_operands (const char *name, rtx insn, rtx ops[], int count);
+extern rtx tms9900_fixup_call_target (rtx);

--- a/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.c
+++ b/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.c
@@ -1505,3 +1505,21 @@ extern void tms9900_debug_operands (const char *name, rtx insn, rtx ops[], int c
     }
 }
 
+/* A constant-address call builds (mem:FUNCTION_MODE (const_int N)), which is
+ bit-identical to a data load at N (FUNCTION_MODE == HImode).  CSE then
+ forwards a known data value into the call target.  Mark such call MEMs
+ volatile so they are never value-numbered/forwarded -- same mechanism as a
+ volatile source access.  Only const-int addresses can collide, so leave
+ symbol and register targets alone.  */
+rtx tms9900_fixup_call_target (rtx target)
+{
+    if (MEM_P (target) && CONST_INT_P (XEXP (target, 0)))
+    {
+        rtx mem = gen_rtx_MEM (GET_MODE (target), XEXP (target, 0));
+        MEM_VOLATILE_P (mem) = 1;
+        MEM_READONLY_P (mem) = 1;   /* it's code, it doesn't change */
+        return mem;
+    }
+    
+    return target;
+}

--- a/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.c
+++ b/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.c
@@ -1513,13 +1513,25 @@ extern void tms9900_debug_operands (const char *name, rtx insn, rtx ops[], int c
  symbol and register targets alone.  */
 rtx tms9900_fixup_call_target (rtx target)
 {
-    if (MEM_P (target) && CONST_INT_P (XEXP (target, 0)))
+    rtx addr;
+    if (!MEM_P (target)) {
+        return target;
+    }
+        
+    addr = XEXP (target, 0);
+    
+    /* A numeric call address -- or a register that may have been value-numbered
+    to one -- collides with a same-address data load (FUNCTION_MODE == HImode).
+    Mark such call targets volatile so CSE/gcse won't forward a data value in.
+    Symbol/label targets can't collide, so leave them fully optimizable.  */
+    
+    if (REG_P (addr) || CONST_INT_P (addr))
     {
-        rtx mem = gen_rtx_MEM (GET_MODE (target), XEXP (target, 0));
+        rtx mem = gen_rtx_MEM (GET_MODE (target), addr);
         MEM_VOLATILE_P (mem) = 1;
-        MEM_READONLY_P (mem) = 1;   /* it's code, it doesn't change */
         return mem;
     }
     
     return target;
 }
+

--- a/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.md
+++ b/dev/gcc-4.4.0/gcc/config/tms9900/tms9900.md
@@ -104,8 +104,8 @@
 
 ;;-------------------------------------------------------------------
 ;; Jump to a subroutine which returns a value
-(define_insn "call"
-  [(call (match_operand:HI 0 "general_operand" "rR,Q")
+(define_insn "*call_internal"
+  [(call (match_operand:HI 0 "general_operand" "R,Q")
          (match_operand:HI 1 "general_operand"  "g,g"))
   ]
   ""
@@ -123,9 +123,9 @@
 
 ;-------------------------------------------------------------------
 ; Jump to a subroutine which returns a value
-(define_insn "call_value"
+(define_insn "*call_value_internal"
   [(set (match_operand 0 "" "")
-        (call (match_operand:HI 1 "general_operand" "rR,Q")
+        (call (match_operand:HI 1 "general_operand" "R,Q")
 	      (match_operand:HI 2 "general_operand" "g,g")))
   ]
   ""
@@ -139,6 +139,23 @@
   }
   [(set_attr "length" "2,4")]
 )
+
+(define_expand "call"
+    [(call (match_operand:HI 0 "memory_operand" "")
+           (match_operand:HI 1 "general_operand" ""))]
+    ""
+  {
+    operands[0] = tms9900_fixup_call_target (operands[0]);
+  })
+
+(define_expand "call_value"
+    [(set (match_operand 0 "" "")
+          (call (match_operand:HI 1 "memory_operand" "")
+                (match_operand:HI 2 "general_operand" "")))]
+    ""
+  {
+    operands[1] = tms9900_fixup_call_target (operands[1]);
+  })
 
 ;; The O2 and O3 optimise options replace BL @xxx with LI Ry,xxx and BL *Ry
 ;; when the BL is inside a loop, even though the LI is also inside the loop,


### PR DESCRIPTION
This handles an edge case:

if ((*(unsigned int*)0x7e00) == 0xc24b) {
    // that's hopefully our code! else return!
    ((void(*)(void))0x7e00)();
}

Will branch to 0xc24b. Actually, it won't even do that, it loads 0xc24b into r1 and does "b r1" (no indirect).

Basically, the compiler was set to equate a branch target like this with a memory word, and since the comparison appeared to say they were equal, it loaded the constant and tried to branch improperly to that.

Per Claude:

At expand, both the comparison load and the call target are (mem:HI ...) at the same address 0x7e00, and the call MEM is in alias set 0 (aliases everything):

  ;; comparison:   (mem:HI (reg 23))   reg23 = 0x7e00     alias set [2]
  ;; call target:  (call (mem:HI (reg 24) [0 S2 A16]) ...) reg24 = 0x7e00   alias set [0]

Because the call target is a plain mem:HI with the same mode and address as the data load, CSE value-numbers them as identical and forwards the known content (0x1234) into the call. 

Root cause pinpointed: #define FUNCTION_MODE HImode. The MEM inside a (call ...) rtx is built in FUNCTION_MODE, so a call to a constant address is (mem:HImode 0x7e00) — bit-for-bit the same rtx as a 16-bit unsigned int load *(unsigned int*)0x7e00. CSE value-numbers them as one expression and forwards the compared constant into the call target. This is why it only triggers when the call address equals a same-width load in the condition.

The solution is being more specific about what that function pointer call is, so it doesn't match a simple memory address.

Have tested my local build but messed up my local branch, so double check this. It looks correct on my end though, including just the new code.